### PR TITLE
Implement support for ecl

### DIFF
--- a/util/hmm.lisp
+++ b/util/hmm.lisp
@@ -160,7 +160,8 @@
   #+mcl (ccl::make-float-from-fixnums 0 0 2047 -1)
   #+ccl -1E++0
   #+sbcl sb-ext:single-float-negative-infinity
-  #-(or ccl allegro lucid cmu mcl sbcl)
+  #+ecl ext:single-float-negative-infinity
+  #-(or ccl allegro lucid cmu mcl sbcl ecl)
   (error "Don't know how to represent -infinity."))
 
 (defstruct (hmm-est

--- a/util/variable-storage.lisp
+++ b/util/variable-storage.lisp
@@ -39,7 +39,7 @@
       (declare (fixnum x))
       (let ((ans 0))
 	(declare (fixnum ans))
-	#-x86-64
+	#-(or x86_64 x86-64)
         (progn
           (unless (zerop (fash x -16))
             (setf ans 16
@@ -48,7 +48,7 @@
             (setf ans (f+ ans 8)
                   x (fash x -8)))
           (f+ ans (aref length-table x)))
-	#+x86-64
+	#+(or x86_64 x86-64)
         (progn
           (unless (zerop (fash x -32))
             (setf ans 32


### PR DESCRIPTION
* util/hmm.lisp (+negative-infinity+): Insert read time
  condition for ecl.

* util/variable-storage.lisp (fast-integer-length): ecl uses :x86_64
  instead of :x86-64 as its conditional.

These changes are needed to make tagger run on embedded common lisp. However, it will only run on the git branch develop as there were some breaking bugs in v16. 